### PR TITLE
Fix printf statement that is causing error

### DIFF
--- a/control_system_stack/thruster_converter/src/thruster.cpp
+++ b/control_system_stack/thruster_converter/src/thruster.cpp
@@ -148,7 +148,6 @@ int main(int argc,char** argv)
 
     while(ros::ok())
     {
-	printf("Output : %s", _output);
         _pub.publish(_output);
         ros::spinOnce();
         looprate.sleep();


### PR DESCRIPTION
- thruster_converter package can't be built
- why this bug was introduced is not clear. Delve into git history.

Signed-off-by: Siddharth Kannan siddharthkannan@tutanota.com
